### PR TITLE
Changed to explicit casting

### DIFF
--- a/src/depthcloud_encoder.cpp
+++ b/src/depthcloud_encoder.cpp
@@ -231,8 +231,8 @@ void DepthCloudEncoder::process(const sensor_msgs::ImageConstPtr& depth_msg,
     std::size_t y, x, left_x, top_y, width_x, width_y;
 
     // calculate borders to crop input image to crop_size X crop_size
-    int top_bottom_corner = (input_height - crop_size) / 2;
-    int left_right_corner = (input_width - crop_size) / 2;
+    int top_bottom_corner = (static_cast<int>(input_height) - static_cast<int>(crop_size)) / 2;
+    int left_right_corner = (static_cast<int>(input_width) - static_cast<int>(crop_size)) / 2;
 
     if (top_bottom_corner < 0)
     {


### PR DESCRIPTION
There is a possibility that an overflow happens in the equation (int) = (unsigned int) - (unsigned int). 
In my PC, 'top_bottom_corner = (480 - 512) / 2' became large positive value and skipped 'if (top_bottom_corner < 0)'. Then It causes segmentation fault. You may want to use explicit casting to avoid that.