### PR TITLE
Develop closecloud encoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(depthcloud_encoder)
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED cv_bridge sensor_msgs image_transport message_filters roscpp)
+find_package(catkin REQUIRED cv_bridge sensor_msgs image_transport message_filters roscpp pcl_conversions pcl_ros tf_conversions)
 find_package(Boost REQUIRED COMPONENTS system thread)
 
 ###################################################

--- a/include/depthcloud_encoder/depthcloud_encoder.h
+++ b/include/depthcloud_encoder/depthcloud_encoder.h
@@ -113,6 +113,7 @@ protected:
   std::string rgb_image_topic_;
   std::string cloud_topic_;
   std::string camera_frame_id_;
+  std::string depth_source_;
 
   tf::TransformListener tf_listener_;
 

--- a/include/depthcloud_encoder/depthcloud_encoder.h
+++ b/include/depthcloud_encoder/depthcloud_encoder.h
@@ -50,6 +50,12 @@
 #include <message_filters/synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>
 
+#include <tf/transform_listener.h>
+#include <geometry_msgs/TransformStamped.h>
+
+#include <sensor_msgs/PointCloud2.h>
+#include <pcl/point_types.h>
+
 #include "ros/ros.h"
 
 namespace depthcloud
@@ -66,7 +72,10 @@ protected:
   void connectCb();
 
   void subscribe(std::string& depth_topic, std::string& color_topic);
+  void subscribeCloud(std::string& cloud_topic);
   void unsubscribe();
+
+  void cloudCB(const sensor_msgs::PointCloud2& cloud_msg);
 
   void depthCB(const sensor_msgs::ImageConstPtr& depth_msg);
 
@@ -76,6 +85,7 @@ protected:
                           sensor_msgs::ImagePtr depth_int_msg,
                           sensor_msgs::ImagePtr mask_msg);
 
+  void cloudToDepth(const sensor_msgs::PointCloud2& cloud_msg, sensor_msgs::ImagePtr depth_msg, sensor_msgs::ImagePtr color_msg);
   void process(const sensor_msgs::ImageConstPtr& depth_msg, const sensor_msgs::ImageConstPtr& color_msg, const std::size_t crop_size);
 
 
@@ -88,6 +98,7 @@ protected:
   // ROS stuff
   boost::shared_ptr<image_transport::SubscriberFilter > depth_sub_;
   boost::shared_ptr<image_transport::SubscriberFilter > color_sub_;
+  ros::Subscriber cloud_sub_;
 
   boost::shared_ptr<SynchronizerDepthColor> sync_depth_color_;
 
@@ -100,7 +111,14 @@ protected:
 
   std::string depthmap_topic_;
   std::string rgb_image_topic_;
+  std::string cloud_topic_;
+  std::string camera_frame_id_;
 
+  tf::TransformListener tf_listener_;
+
+  double f_;
+
+  bool connectivityExceptionFlag, lookupExceptionFlag;
 };
 
 }

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,8 @@
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>pcl_ros</build_depend>
+  <build_depend>pcl_conversions</build_depend>
+  <build_depend>tf_conversions</build_depend>
   
   <run_depend>cv_bridge</run_depend>
   <run_depend>image_transport</run_depend>
@@ -27,4 +29,6 @@
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>pcl_ros</run_depend>
+  <run_depend>pcl_conversions</run_depend>
+  <run_depend>tf_conversions</run_depend>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -19,10 +19,12 @@
   <build_depend>message_filters</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>pcl_ros</build_depend>
   
   <run_depend>cv_bridge</run_depend>
   <run_depend>image_transport</run_depend>
   <run_depend>message_filters</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
+  <run_depend>pcl_ros</run_depend>
 </package>

--- a/src/depthcloud_encoder.cpp
+++ b/src/depthcloud_encoder.cpp
@@ -231,8 +231,8 @@ void DepthCloudEncoder::process(const sensor_msgs::ImageConstPtr& depth_msg,
     std::size_t y, x, left_x, top_y, width_x, width_y;
 
     // calculate borders to crop input image to crop_size X crop_size
-    int top_bottom_corner = (input_height - crop_size) / 2;
-    int left_right_corner = (input_width - crop_size) / 2;
+    int top_bottom_corner = (static_cast<int>(input_height) - static_cast<int>(crop_size)) / 2;
+    int left_right_corner = (static_cast<int>(input_width) - static_cast<int>(crop_size)) / 2;
 
     if (top_bottom_corner < 0)
     {

--- a/src/depthcloud_node.cpp
+++ b/src/depthcloud_node.cpp
@@ -43,7 +43,7 @@ int main(int argc, char **argv){
 
   depthcloud::DepthCloudEncoder depth_enc(nh, pnh);
 
-  ros::AsyncSpinner spinner(8);
+  ros::AsyncSpinner spinner(2);
 
   spinner.start();
   ros::waitForShutdown();


### PR DESCRIPTION
This pull request adds two features: encoding a pointcloud instead of just depth images and improving the resolution by factor 6 by shrinking the range to 0-2m and using the RGB channels separately to encode depth.

The ros3djs pull request 107 depends on this one to render the depthclouds correctly in this new resolution.
