### PR TITLE
parameterize max_depth_per_tile

### DIFF
--- a/include/depthcloud_encoder/depthcloud_encoder.h
+++ b/include/depthcloud_encoder/depthcloud_encoder.h
@@ -118,6 +118,7 @@ protected:
   tf::TransformListener tf_listener_;
 
   double f_;
+  float max_depth_per_tile_;
 
   bool connectivityExceptionFlag, lookupExceptionFlag;
 };


### PR DESCRIPTION
Adds an ability to change the `max_depth_per_tile` factor so we can control the desired depth range. A PR to allow a tunable range in the `DepthCloud` will shortly follow.